### PR TITLE
Modify piping to /dev/null in order to fix #1

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -19,7 +19,7 @@ function f_notifyme {
             -message "exited with status $LAST_EXIT_CODE" \
             -activate "$TERMINAL_BUNDLE_ID" \
             -sender "$TERMINAL_BUNDLE_ID" \
-            -group "$TERMINAL_BUNDLE_ID" 2>&1 > /dev/null
+            -group "$TERMINAL_BUNDLE_ID" > /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
Changing the order of the parameter fixes and closes #1 